### PR TITLE
Add `distilabel` in `Tools` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Thanks for all the great contributors on GitHub!🔥⚡🔥
 
 - [**DataDreamer: A Tool for Synthetic Data Generation and Reproducible LLM Workflows.**](https://arxiv.org/abs/2402.10379) *Ajay Patel, Colin Raffel, Chris Callison-Burch.* ACL 2024.
 - [**AgentInstruct: Toward Generative Teaching with Agentic Flows.**](https://arxiv.org/abs/2407.03502) *Arindam Mitra, Luciano Del Corro, Guoqing Zheng, Shweti Mahajan, Dany Rouhana, Andres Codas, Yadong Lu, Wei-ge Chen, Olga Vrousgos, Corby Rosset, Fillipe Silva, Hamed Khanpour, Yash Lara, Ahmed Awadallah.* Arxiv 2024.
+- [**Distilabel: a framework for building synthetic data generation pipelines**](https://github.com/argilla-io/distilabel) *Álvaro Bartolomé Del Canto, Gabriel Martín Blázquez, Agustín Piqueres Lajarín and Daniel Vila Suero.* GitHub 2024.
 
 ## 6. Blogs
 


### PR DESCRIPTION
## Description

I've added `distilabel`, a framework/library that allows to build synthetic text data generation pipelines arranging the steps of the pipeline in a DAG. `distilabel` is integrated with all the major LLM APIs/engines and has many cool features such as structured data generation, caching, etc.