### PR TITLE
Add SynthPAI paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Thanks for all the great contributors on GitHub!🔥⚡🔥
 
 - [**Synthetic-Text-To-SQL: A synthetic dataset for training language models to generate SQL queries from natural language prompts.**](https://huggingface.co/datasets/gretelai/synthetic-text-to-sql) *Meyer, Yev and Emadi, Marjan and Nathawani, Dhruv and Ramaswamy, Lipika and Boyd, Kendrick and Van Segbroeck, Maarten and Grossman, Matthew and Mlocek, Piotr and Newberry, Drew.* Huggingface 2024.
 - [**Open Artificial Knowledge**](https://huggingface.co/datasets/tabularisai/oak) *Vadim Borisov, Richard Schreiber.* ICML Workshop 2024.
+- [**SynthPAI: A Synthetic Dataset for Personal Attribute Inference**](https://arxiv.org/abs/2406.07217) *Hanna Yukhymenko, Robin Staab, Mark Vero, Martin Vechev.* NeurIPS D&B 2024
 
 ## 5. Tools
 


### PR DESCRIPTION
This PR adds the paper for SynthPAI dataset.

_TL;DR: We build an LLM-agent simulation framework for Reddit to generate synthetic data to advance inference-based privacy research._

Paper: https://arxiv.org/abs/2406.07217
Dataset: https://huggingface.co/datasets/RobinSta/SynthPAI
Code: https://github.com/eth-sri/synthpai